### PR TITLE
gx: update go-cid

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.7: Qmdqe1sKBpz6W8xFDptGfmzgCPQ5CXNuQPhZeELqMowgsQ
+1.0.8: QmTbas51oodp3ZJrqsWYs1yqSxcD7LEJBv4djRV2VrY8wv

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "Qmc3UwSvJkntxu2gKDPCqJEzmhqVeJtTbrVxJm6tsdmMF1",
+      "hash": "Qme4ThG6LN6EMrMYyf2AMywAZaGbTYxQu4njfcSSkcisLi",
       "name": "go-ipfs-chunker",
-      "version": "0.0.8"
+      "version": "0.0.9"
     },
     {
       "author": "whyrusleeping",
@@ -78,6 +78,6 @@
   "license": "",
   "name": "go-unixfs",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.7"
+  "version": "1.0.8"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/186
- https://github.com/ipfs/go-ipld-git/pull/22
- https://github.com/ipfs/go-ipfs-chunker/pull/2
- https://github.com/ipfs/go-ipfs-exchange-offline/pull/4
- https://github.com/libp2p/go-libp2p-routing-helpers/pull/4
- https://github.com/libp2p/go-libp2p-pubsub-router/pull/5
- https://github.com/ipfs/go-path/pull/4


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace