### PR TITLE
Use EnumerateChildrenAsync in for enumerating HAMT links

### DIFF
--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -393,7 +393,9 @@ func (ds *Shard) EnumLinks(ctx context.Context) ([]*ipld.Link, error) {
 		return nil
 	})
 
-	err := dag.EnumerateChildrenAsync(ctx, getLinks, ds.nd.Cid(), func(c cid.Cid) bool { return true })
+	cset := cid.NewSet()
+
+	err := dag.EnumerateChildrenAsync(ctx, getLinks, ds.nd.Cid(), cset.Visit)
 	return links, err
 }
 

--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -105,7 +105,6 @@ func NewHamtFromDag(dserv ipld.DAGService, nd ipld.Node) (*Shard, error) {
 		return nil, err
 	}
 
-
 	if fsn.Type() != format.THAMTShard {
 		return nil, fmt.Errorf("node was not a dir shard")
 	}
@@ -203,6 +202,14 @@ func (sv *shardValue) Label() string {
 	return sv.key
 }
 
+func (ds *Shard) makeShardValue(lnk *ipld.Link) *shardValue {
+	lnk2 := *lnk
+	return &shardValue{
+		key: lnk.Name[ds.maxpadlen:],
+		val: &lnk2,
+	}
+}
+
 func hash(val []byte) []byte {
 	h := murmur3.New64()
 	h.Write(val)
@@ -254,6 +261,24 @@ func (ds *Shard) Find(ctx context.Context, name string) (*ipld.Link, error) {
 	return out, nil
 }
 
+type linkType int
+
+const (
+	invalidLink linkType = iota
+	shardLink
+	shardValueLink
+)
+
+func (ds *Shard) childLinkType(lnk *ipld.Link) (linkType, error) {
+	if len(lnk.Name) < ds.maxpadlen {
+		return invalidLink, fmt.Errorf("invalid link name '%s'", lnk.Name)
+	}
+	if len(lnk.Name) == ds.maxpadlen {
+		return shardLink, nil
+	}
+	return shardValueLink, nil
+}
+
 // getChild returns the i'th child of this shard. If it is cached in the
 // children array, it will return it from there. Otherwise, it loads the child
 // node from disk.
@@ -278,12 +303,13 @@ func (ds *Shard) getChild(ctx context.Context, i int) (child, error) {
 // as a 'child' interface
 func (ds *Shard) loadChild(ctx context.Context, i int) (child, error) {
 	lnk := ds.nd.Links()[i]
-	if len(lnk.Name) < ds.maxpadlen {
-		return nil, fmt.Errorf("invalid link name '%s'", lnk.Name)
+	lnkLinkType, err := ds.childLinkType(lnk)
+	if err != nil {
+		return nil, err
 	}
 
 	var c child
-	if len(lnk.Name) == ds.maxpadlen {
+	if lnkLinkType == shardLink {
 		nd, err := lnk.GetNode(ctx, ds.dserv)
 		if err != nil {
 			return nil, err
@@ -295,11 +321,7 @@ func (ds *Shard) loadChild(ctx context.Context, i int) (child, error) {
 
 		c = cds
 	} else {
-		lnk2 := *lnk
-		c = &shardValue{
-			key: lnk.Name[ds.maxpadlen:],
-			val: &lnk2,
-		}
+		c = ds.makeShardValue(lnk)
 	}
 
 	ds.children[i] = c
@@ -386,9 +408,11 @@ func (ds *Shard) EnumLinks(ctx context.Context) ([]*ipld.Link, error) {
 	var links []*ipld.Link
 	var setlk sync.Mutex
 
-	getLinks := ds.makeAsyncTrieGetLinks(func(l *ipld.Link) error {
+	getLinks := makeAsyncTrieGetLinks(ds.dserv, func(sv *shardValue) error {
+		lnk := sv.val
+		lnk.Name = sv.key
 		setlk.Lock()
-		links = append(links, l)
+		links = append(links, lnk)
 		setlk.Unlock()
 		return nil
 	})
@@ -409,29 +433,34 @@ func (ds *Shard) ForEachLink(ctx context.Context, f func(*ipld.Link) error) erro
 	})
 }
 
-func (ds *Shard) makeAsyncTrieGetLinks(cb func(*ipld.Link) error) dag.GetLinks {
+// makeAsyncTrieGetLinks builds a getLinks function that can be used with EnumerateChildrenAsync
+// to iterate a HAMT shard. It takes an IPLD Dag Service to fetch nodes, and a call back that will get called
+// on all links to leaf nodes in a HAMT tree, so they can be collected for an EnumLinks operation
+func makeAsyncTrieGetLinks(dagService ipld.DAGService, onShardValue func(*shardValue) error) dag.GetLinks {
 
-	return func(ctx context.Context, c cid.Cid) ([]*ipld.Link, error) {
-		node, err := ds.dserv.Get(ctx, c)
+	return func(ctx context.Context, currentCid cid.Cid) ([]*ipld.Link, error) {
+		node, err := dagService.Get(ctx, currentCid)
 		if err != nil {
 			return nil, err
 		}
-		cds, err := NewHamtFromDag(ds.dserv, node)
+		directoryShard, err := NewHamtFromDag(dagService, node)
 		if err != nil {
 			return nil, err
 		}
 
-		childShards := make([]*ipld.Link, 0, len(cds.children))
-		for idx := range cds.children {
-			lnk := cds.nd.Links()[idx]
+		childShards := make([]*ipld.Link, 0, len(directoryShard.children))
+		for idx := range directoryShard.children {
+			lnk := directoryShard.nd.Links()[idx]
+			lnkLinkType, err := directoryShard.childLinkType(lnk)
 
-			if len(lnk.Name) < cds.maxpadlen {
-				return nil, fmt.Errorf("invalid link name '%s'", lnk.Name)
+			if err != nil {
+				return nil, err
 			}
-			if len(lnk.Name) == cds.maxpadlen {
+			if lnkLinkType == shardLink {
 				childShards = append(childShards, lnk)
 			} else {
-				cb(lnk)
+				sv := directoryShard.makeShardValue(lnk)
+				onShardValue(sv)
 			}
 		}
 		return childShards, nil

--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -449,8 +449,9 @@ func makeAsyncTrieGetLinks(dagService ipld.DAGService, onShardValue func(*shardV
 		}
 
 		childShards := make([]*ipld.Link, 0, len(directoryShard.children))
+		links := directoryShard.nd.Links()
 		for idx := range directoryShard.children {
-			lnk := directoryShard.nd.Links()[idx]
+			lnk := links[idx]
 			lnkLinkType, err := directoryShard.childLinkType(lnk)
 
 			if err != nil {
@@ -460,7 +461,10 @@ func makeAsyncTrieGetLinks(dagService ipld.DAGService, onShardValue func(*shardV
 				childShards = append(childShards, lnk)
 			} else {
 				sv := directoryShard.makeShardValue(lnk)
-				onShardValue(sv)
+				err := onShardValue(sv)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		return childShards, nil

--- a/hamt/hamt_test.go
+++ b/hamt/hamt_test.go
@@ -11,6 +11,7 @@ import (
 
 	dag "github.com/ipfs/go-merkledag"
 	mdtest "github.com/ipfs/go-merkledag/test"
+
 	ft "github.com/ipfs/go-unixfs"
 
 	ipld "github.com/ipfs/go-ipld-format"
@@ -100,6 +101,8 @@ func assertSerializationWorks(ds ipld.DAGService, s *Shard) error {
 		return fmt.Errorf("links arrays are different sizes")
 	}
 
+	sort.Stable(dag.LinkSlice(linksA))
+	sort.Stable(dag.LinkSlice(linksB))
 	for i, a := range linksA {
 		b := linksB[i]
 		if a.Name != b.Name {
@@ -280,13 +283,16 @@ func TestSetAfterMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	empty := ft.EmptyDirNode()
 	for i := 0; i < 100; i++ {
+		empty := ft.EmptyDirNode()
 		err := nds.Set(ctx, fmt.Sprintf("moredirs%d", i), empty)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
+
+	nd, err = nds.Node()
+	nds, err = NewHamtFromDag(ds, nd)
 
 	links, err := nds.EnumLinks(ctx)
 	if err != nil {
@@ -318,6 +324,9 @@ func TestDuplicateAddShard(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	node, err := dir.Node()
+	dir, err = NewHamtFromDag(ds, node)
 
 	lnks, err := dir.EnumLinks(ctx)
 	if err != nil {
@@ -410,6 +419,9 @@ func TestRemoveElemsAfterMarshal(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
+	nd, err = nds.Node()
+	nds, err = NewHamtFromDag(ds, nd)
 
 	links, err := nds.EnumLinks(ctx)
 	if err != nil {


### PR DESCRIPTION
# Goals

Speed up LS operation on sharded directories [#4908](https://github.com/ipfs/go-ipfs/issues/4908)
Test the use of [EnumerateChildrenAsync](https://github.com/ipfs/go-merkledag/blob/master/merkledag.go#L351) as a fast way of fetching an arbitrary MerkleDAG w/o concern for order (https://github.com/ipfs/go-ipfs/issues/5487)

# Implementation

In the `EnumLinks` method for HAMT, instead of calling ForEachLink (synchronous), use `EnumerateChildrenAsync` 

`EnumerateChildrenAsync` requires a root CID, a `GetLinks` function which returns a list of child IPLD Links to traverse for a given CID, and a `visit` function which returns a boolean of whether to traverse a given CID. In our case, `visit` is a function that just returns true (always visit), and filtering nodes to visit is instead handled by filtering the child links returned by our `getLinks` function. The `getLinks` function is generated by `makeAsyncTrieGetLinks` and does the following:

- Given a CID for a directory shard, fetch the full node for that shard.
- Enumerate the nodes child links and determine which are shards vs shardValues (i.e. actual files) using the name of the link (above a certain length = shard value)
- For each shardValue, call the callback passed to `makeAsyncTrieGetLinks` so that `EnumLinks` can add the value to the links it will return
- Return from the function all of the links that are actual shards so `EnumerateChildrenAsync` will visit them
- `EnumLinks` uses a mutex when appending to the list of links so that appends are thread safe

# For Discussion

In tandem with increasing the [FetchConcurrency](https://github.com/ipfs/go-merkledag/blob/master/merkledag.go#L345) for `EnumerateChildrenAsync` to 128 and adding sessions to the LS operation, this produces the following results for fetching the Wikipedia directory (running `ipfs repo gc && time ipfs ls --resolve-type=false /ipfs/QmT5NvUtoM5nWFfrQdVrFtvGfKFmG7AHE8P34isapyhCxX/wiki/`):

From the internet: `ipfs ls --resolve-type=false   6.08s user 0.86s system 0% cpu 38:30.81 total`
From a machine on local network: `ipfs ls --resolve-type=false   6.68s user 1.13s system 5% cpu 2:17.42 total`

The improvements are simply not as dramatic with the current `FetchConcurrency` of 8. I am also going to experiment with adding `GetMany` calls inside make trie as a way of prefetching children with greater overall concurrency without changing `FetchConcurrency`.

I also wonder if it is neccesary to actually call NewHamtFromDag and whether there are potentially improvements in performance/memory/GC usage by skipping this extra processing step.

I am going to submit a seperate PR for adding sessions to LS, which I think can be merged independently.

Also still need to add tests -- this is not a final implementation