### PR TITLE
Fix comments relative to DefaultLinksPerBlock

### DIFF
--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -28,10 +28,11 @@ var roughLinkSize = 34 + 8 + 5   // sha256 multihash + size + no name + protobuf
 // For now, we use:
 //
 //   var roughLinkBlockSize = 1 << 13 // 8KB
-//   var roughLinkSize = 288          // sha256 + framing + name
+//   var roughLinkSize = 34 + 8 + 5   // sha256 multihash + size + no name
+//                                    // + protobuf framing
 //   var DefaultLinksPerBlock = (roughLinkBlockSize / roughLinkSize)
-//
-// See calc_test.go
+//                            = ( 8192 / 47 )
+//                            = (approximately) 174
 var DefaultLinksPerBlock = roughLinkBlockSize / roughLinkSize
 
 // ErrSizeLimitExceeded signals that a block is larger than BlockSizeLimit.


### PR DESCRIPTION
When try to write the patch for https://github.com/ipfs/go-ipfs/issues/5135. I found that the comments in [importer/helpers/helpers.go](https://github.com/ipfs/go-unixfs/blob/master/importer/helpers/helpers.go) is not correct.  Reference https://github.com/ipfs/go-ipfs/issues/5135#issuecomment-423797051.