### PR TITLE
feat(Directory): Add EnumLinksAsync method

### DIFF
--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -469,7 +469,13 @@ func makeAsyncTrieGetLinks(dagService ipld.DAGService, linkResults chan<- format
 			if lnkLinkType == shardLink {
 				childShards = append(childShards, lnk)
 			} else {
-				emitResult(ctx, linkResults, format.LinkResult{Link: lnk, Err: nil})
+				sv, err := directoryShard.makeShardValue(lnk)
+				if err != nil {
+					return nil, err
+				}
+				formattedLink := sv.val
+				formattedLink.Name = sv.key
+				emitResult(ctx, linkResults, format.LinkResult{Link: formattedLink, Err: nil})
 			}
 		}
 		return childShards, nil

--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -29,9 +29,8 @@ import (
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	dag "github.com/ipfs/go-merkledag"
-	"github.com/spaolacci/murmur3"
-
 	format "github.com/ipfs/go-unixfs"
+	"github.com/spaolacci/murmur3"
 )
 
 const (
@@ -401,10 +400,8 @@ func (ds *Shard) getValue(ctx context.Context, hv *hashBits, key string, cb func
 func (ds *Shard) EnumLinks(ctx context.Context) ([]*ipld.Link, error) {
 	var links []*ipld.Link
 
-	linkResults, err := ds.EnumLinksAsync(ctx)
-	if err != nil {
-		return nil, err
-	}
+	linkResults := ds.EnumLinksAsync(ctx)
+
 	for linkResult := range linkResults {
 		if linkResult.Err != nil {
 			return links, linkResult.Err
@@ -426,7 +423,7 @@ func (ds *Shard) ForEachLink(ctx context.Context, f func(*ipld.Link) error) erro
 
 // EnumLinksAsync returns a channel which will receive Links in the directory
 // as they are enumerated, where order is not gauranteed
-func (ds *Shard) EnumLinksAsync(ctx context.Context) (<-chan format.LinkResult, error) {
+func (ds *Shard) EnumLinksAsync(ctx context.Context) <-chan format.LinkResult {
 	linkResults := make(chan format.LinkResult)
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
@@ -439,7 +436,7 @@ func (ds *Shard) EnumLinksAsync(ctx context.Context) (<-chan format.LinkResult, 
 			emitResult(ctx, linkResults, format.LinkResult{Link: nil, Err: err})
 		}
 	}()
-	return linkResults, nil
+	return linkResults
 }
 
 // makeAsyncTrieGetLinks builds a getLinks function that can be used with EnumerateChildrenAsync

--- a/hamt/hamt_test.go
+++ b/hamt/hamt_test.go
@@ -337,10 +337,8 @@ func TestEnumLinksAsync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	linkResults, err := nds.EnumLinksAsync(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	linkResults := nds.EnumLinksAsync(ctx)
+
 	var linksB []*ipld.Link
 
 	for linkResult := range linkResults {

--- a/hamt/hamt_test.go
+++ b/hamt/hamt_test.go
@@ -74,28 +74,7 @@ func assertLink(s *Shard, name string, found bool) error {
 	}
 }
 
-func assertSerializationWorks(ds ipld.DAGService, s *Shard) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	nd, err := s.Node()
-	if err != nil {
-		return err
-	}
-
-	nds, err := NewHamtFromDag(ds, nd)
-	if err != nil {
-		return err
-	}
-
-	linksA, err := s.EnumLinks(ctx)
-	if err != nil {
-		return err
-	}
-
-	linksB, err := nds.EnumLinks(ctx)
-	if err != nil {
-		return err
-	}
+func assertLinksEqual(linksA []*ipld.Link, linksB []*ipld.Link) error {
 
 	if len(linksA) != len(linksB) {
 		return fmt.Errorf("links arrays are different sizes")
@@ -119,6 +98,32 @@ func assertSerializationWorks(ds ipld.DAGService, s *Shard) error {
 	}
 
 	return nil
+}
+
+func assertSerializationWorks(ds ipld.DAGService, s *Shard) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nd, err := s.Node()
+	if err != nil {
+		return err
+	}
+
+	nds, err := NewHamtFromDag(ds, nd)
+	if err != nil {
+		return err
+	}
+
+	linksA, err := s.EnumLinks(ctx)
+	if err != nil {
+		return err
+	}
+
+	linksB, err := nds.EnumLinks(ctx)
+	if err != nil {
+		return err
+	}
+
+	return assertLinksEqual(linksA, linksB)
 }
 
 func TestBasicSet(t *testing.T) {
@@ -304,6 +309,48 @@ func TestSetAfterMarshal(t *testing.T) {
 	}
 
 	err = assertSerializationWorks(ds, nds)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnumLinksAsync(t *testing.T) {
+	ds := mdtest.Mock()
+	_, s, err := makeDir(ds, 300)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	nd, err := s.Node()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nds, err := NewHamtFromDag(ds, nd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	linksA, err := nds.EnumLinks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	linkResults, err := nds.EnumLinksAsync(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var linksB []*ipld.Link
+
+	for linkResult := range linkResults {
+		if linkResult.Err != nil {
+			t.Fatal(linkResult.Err)
+		}
+		linksB = append(linksB, linkResult.Link)
+	}
+
+	err = assertLinksEqual(linksA, linksB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/io/directory.go
+++ b/io/directory.go
@@ -153,9 +153,13 @@ func (d *BasicDirectory) EnumLinksAsync(ctx context.Context) (<-chan format.Link
 	go func() {
 		defer close(linkResults)
 		for _, l := range d.node.Links() {
-			linkResults <- format.LinkResult{
+			select {
+			case linkResults <- format.LinkResult{
 				Link: l,
 				Err:  nil,
+			}:
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()

--- a/io/directory.go
+++ b/io/directory.go
@@ -41,7 +41,7 @@ type Directory interface {
 
 	// EnumLinksAsync returns a channel which will receive Links in the directory
 	// as they are enumerated, where order is not gauranteed
-	EnumLinksAsync(context.Context) (<-chan format.LinkResult, error)
+	EnumLinksAsync(context.Context) <-chan format.LinkResult
 
 	// Links returns the all the links in the directory node.
 	Links(context.Context) ([]*ipld.Link, error)
@@ -148,7 +148,7 @@ func (d *BasicDirectory) AddChild(ctx context.Context, name string, node ipld.No
 
 // EnumLinksAsync returns a channel which will receive Links in the directory
 // as they are enumerated, where order is not gauranteed
-func (d *BasicDirectory) EnumLinksAsync(ctx context.Context) (<-chan format.LinkResult, error) {
+func (d *BasicDirectory) EnumLinksAsync(ctx context.Context) <-chan format.LinkResult {
 	linkResults := make(chan format.LinkResult)
 	go func() {
 		defer close(linkResults)
@@ -163,7 +163,7 @@ func (d *BasicDirectory) EnumLinksAsync(ctx context.Context) (<-chan format.Link
 			}
 		}
 	}()
-	return linkResults, nil
+	return linkResults
 }
 
 // ForEachLink implements the `Directory` interface.
@@ -253,7 +253,7 @@ func (d *HAMTDirectory) ForEachLink(ctx context.Context, f func(*ipld.Link) erro
 
 // EnumLinksAsync returns a channel which will receive Links in the directory
 // as they are enumerated, where order is not gauranteed
-func (d *HAMTDirectory) EnumLinksAsync(ctx context.Context) (<-chan format.LinkResult, error) {
+func (d *HAMTDirectory) EnumLinksAsync(ctx context.Context) <-chan format.LinkResult {
 	return d.shard.EnumLinksAsync(ctx)
 }
 

--- a/io/directory_test.go
+++ b/io/directory_test.go
@@ -158,10 +158,7 @@ func TestDirBuilder(t *testing.T) {
 		t.Fatal("wrong number of links", len(links), count)
 	}
 
-	linkResults, err := dir.EnumLinksAsync(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	linkResults := dir.EnumLinksAsync(ctx)
 
 	asyncNames := make(map[string]bool)
 	var asyncLinks []*ipld.Link

--- a/io/directory_test.go
+++ b/io/directory_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	ipld "github.com/ipfs/go-ipld-format"
 	mdtest "github.com/ipfs/go-merkledag/test"
+
 	ft "github.com/ipfs/go-unixfs"
 )
 
@@ -154,5 +156,32 @@ func TestDirBuilder(t *testing.T) {
 
 	if len(links) != count {
 		t.Fatal("wrong number of links", len(links), count)
+	}
+
+	linkResults, err := dir.EnumLinksAsync(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	asyncNames := make(map[string]bool)
+	var asyncLinks []*ipld.Link
+
+	for linkResult := range linkResults {
+		if linkResult.Err != nil {
+			t.Fatal(linkResult.Err)
+		}
+		asyncNames[linkResult.Link.Name] = true
+		asyncLinks = append(asyncLinks, linkResult.Link)
+	}
+
+	for i := 0; i < count; i++ {
+		n := fmt.Sprintf("entry %d", i)
+		if !asyncNames[n] {
+			t.Fatal("COULDNT FIND: ", n)
+		}
+	}
+
+	if len(asyncLinks) != count {
+		t.Fatal("wrong number of links", len(asyncLinks), count)
 	}
 }

--- a/unixfs.go
+++ b/unixfs.go
@@ -9,8 +9,17 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 
 	dag "github.com/ipfs/go-merkledag"
+
+	ipld "github.com/ipfs/go-ipld-format"
 	pb "github.com/ipfs/go-unixfs/pb"
 )
+
+// A LinkResult for any parallel enumeration of links
+// TODO: Should this live in go-ipld-format?
+type LinkResult struct {
+	Link *ipld.Link
+	Err  error
+}
 
 // Shorthands for protobuffer types
 const (


### PR DESCRIPTION
# Goal

child of https://github.com/ipfs/go-ipfs/issues/5600
Implement an EnumLinksAsync method on Directory interface to support streaming version of `ls` command

# Implementation

- Add LinkResult type to unix-fs - is an ipld Link or an error
- Add EnumLinksAsync method to Directory interface, returns channel of directory links or error
- Add EnumLinksAsync method to Shard interface in HAMT, returns channel
of directory links or error
- EnumLinks method in Shard interface in HAMT uses EnumLinksAsync now
- modify makeAsyncTrieGetLinks to use channel

# For Discussion

- Arguably an async link enumeration is sufficiently generic it could live in go-ipld-format, and LinkResult is a type that is not super specific to go-unixfs
- However I would prefer to hold on putting LinkResult in go-ipld-format to a later commit where we a generalized out-of-order parallel walker to IPLD format (essentially moving over enumerateChildrenAsync from go-merkledag)
- Once this is merged, will move on to adding streaming `ls` to go-ipfs