### PR TITLE
fix: correctly handle symlink file sizes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 // indirect
 )
+
+go 1.12

--- a/unixfs_test.go
+++ b/unixfs_test.go
@@ -123,12 +123,21 @@ func TestPBdataTools(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
 
-	_, sizeErr := DataSize(catSym)
-	if sizeErr == nil {
-		t.Fatal("DataSize didn't throw an error when taking the size of a Symlink.")
+func TestSymlinkFilesize(t *testing.T) {
+	path := "/ipfs/adad123123/meowgie.gif"
+	sym, err := SymlinkData(path)
+	if err != nil {
+		t.Fatal(err)
 	}
-
+	size, err := DataSize(sym)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int(size) != len(path) {
+		t.Fatalf("size mismatch: %d != %d", size, len(path))
+	}
 }
 
 func TestMetadata(t *testing.T) {


### PR DESCRIPTION
The file size of a symlink is the symlink data.