### PR TITLE
fix(dagreader): remove a buggy workaround for a gateway issue

### DIFF
--- a/io/dagreader.go
+++ b/io/dagreader.go
@@ -480,6 +480,7 @@ func (dr *dagReader) Seek(offset int64, whence int) (int64, error) {
 // in the `SeekStart` case.
 func (dr *dagReader) resetPosition() {
 	dr.currentNodeData = nil
+	dr.offset = 0
 
 	dr.dagWalker = ipld.NewWalker(dr.ctx, ipld.NewNavigableIPLDNode(dr.rootNode, dr.serv))
 	// TODO: This could be avoided (along with storing the `dr.rootNode` and


### PR DESCRIPTION
We had a hack that "pretended" seeking worked when it didn't as go's HTTP
library uses seeks to determine the file size. However,

1. I'm changing the gateway to actually rely on seeking working as specified.
2. We don't even need this hack. The gateway performs two types of seeks (unless
   a range query is passed):
    1. It seeks to the beginning. We can always shortcut this.
    2. It seeks to the end. The gateway now has a special "lazy" seeker to avoid
      seeking until we actually try to _read_. Therefore, we don't need a hack
      for that either.