### PR TITLE
correct file size for raw node

### DIFF
--- a/io/dagreader.go
+++ b/io/dagreader.go
@@ -56,26 +56,8 @@ func NewDagReader(ctx context.Context, n ipld.Node, serv ipld.NodeGetter) (DagRe
 		}
 
 		switch fsNode.Type() {
-		case unixfs.TFile:
+		case unixfs.TFile, unixfs.TRaw:
 			size = fsNode.FileSize()
-
-		case unixfs.TRaw:
-			stat, err := n.Stat()
-			if err != nil {
-				return nil, err
-			}
-			size = uint64(stat.DataSize)
-			for _, link := range n.Links() {
-				ln, err := link.GetNode(ctx, serv)
-				if err != nil {
-					return nil, err
-				}
-				stat, err := ln.Stat()
-				if err != nil {
-					return nil, err
-				}
-				size += uint64(stat.DataSize)
-			}
 
 		case unixfs.TDirectory, unixfs.THAMTShard:
 			// Dont allow reading directories

--- a/io/dagreader.go
+++ b/io/dagreader.go
@@ -56,8 +56,26 @@ func NewDagReader(ctx context.Context, n ipld.Node, serv ipld.NodeGetter) (DagRe
 		}
 
 		switch fsNode.Type() {
-		case unixfs.TFile, unixfs.TRaw:
+		case unixfs.TFile:
 			size = fsNode.FileSize()
+
+		case unixfs.TRaw:
+			stat, err := n.Stat()
+			if err != nil {
+				return nil, err
+			}
+			size = uint64(stat.DataSize)
+			for _, link := range n.Links() {
+				ln, err := link.GetNode(ctx, serv)
+				if err != nil {
+					return nil, err
+				}
+				stat, err := ln.Stat()
+				if err != nil {
+					return nil, err
+				}
+				size += uint64(stat.DataSize)
+			}
 
 		case unixfs.TDirectory, unixfs.THAMTShard:
 			// Dont allow reading directories

--- a/unixfs.go
+++ b/unixfs.go
@@ -159,9 +159,9 @@ func size(pbdata *pb.Data) (uint64, error) {
 	switch pbdata.GetType() {
 	case pb.Data_Directory, pb.Data_HAMTShard:
 		return 0, errors.New("can't get data size of directory")
-	case pb.Data_File:
+	case pb.Data_File, pb.Data_Raw:
 		return pbdata.GetFilesize(), nil
-	case pb.Data_Symlink, pb.Data_Raw:
+	case pb.Data_Symlink:
 		return uint64(len(pbdata.GetData())), nil
 	default:
 		return 0, errors.New("unrecognized node data type")


### PR DESCRIPTION
While looking at https://github.com/ipfs/go-ipfs/issues/7916 I noticed the file size returned by https://github.com/ipfs/go-ipfs/blob/master/core/commands/get.go#L80 is 0 for this raw dag. 

```
◉ ipfs get QmasYd9docsEaozsdZxCp29yfoZoUJDrvqgkT8Hry66N24
Saving file(s) to QmasYd9docsEaozsdZxCp29yfoZoUJDrvqgkT8Hry66N24
 111.50 KiB / 111.50 KiB [===========================================================================] 100.00% 0s
```

```
◉ curl localhost:8082/ipfs/QmasYd9docsEaozsdZxCp29yfoZoUJDrvqgkT8Hry66N24 -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  111k  100  111k    0     0  13.6M      0 --:--:-- --:--:-- --:--:-- 13.6M
```