### PR TITLE
feat: add UpgradeableDirectory

### DIFF
--- a/io/directory.go
+++ b/io/directory.go
@@ -100,7 +100,7 @@ func NewDirectory(dserv ipld.DAGService) Directory {
 	basicDir := new(BasicDirectory)
 	basicDir.node = format.EmptyDirNode()
 	basicDir.dserv = dserv
-	return UpgradeableDirectory{basicDir}
+	return &UpgradeableDirectory{basicDir}
 }
 
 // ErrNotADir implies that the given node was not a unixfs directory
@@ -308,7 +308,7 @@ var _ Directory = (*UpgradeableDirectory)(nil)
 
 // AddChild implements the `Directory` interface. We check when adding new entries
 // if we should switch to HAMTDirectory according to global option(s).
-func (d UpgradeableDirectory) AddChild(ctx context.Context, name string, nd ipld.Node) error {
+func (d *UpgradeableDirectory) AddChild(ctx context.Context, name string, nd ipld.Node) error {
 	if UseHAMTSharding {
 		if basicDir, ok := d.Directory.(*BasicDirectory); ok {
 			hamtDir, err := basicDir.SwitchToSharding(ctx)

--- a/io/directory_test.go
+++ b/io/directory_test.go
@@ -98,6 +98,30 @@ func TestDuplicateAddDir(t *testing.T) {
 	}
 }
 
+func TestUpgradeableDirectory(t *testing.T) {
+	oldHamtOption := UseHAMTSharding
+	defer func() {UseHAMTSharding = oldHamtOption}()
+
+	ds := mdtest.Mock()
+	UseHAMTSharding = false // Create a BasicDirectory.
+	dir := NewDirectory(ds)
+	if _, ok := dir.(UpgradeableDirectory).Directory.(*BasicDirectory); !ok {
+		t.Fatal("UpgradeableDirectory doesn't contain BasicDirectory")
+	}
+
+	// Any new directory entry will trigger the upgrade to HAMTDirectory
+	UseHAMTSharding = true
+
+	err := dir.AddChild(context.Background(), "test", ft.EmptyDirNode())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := dir.(UpgradeableDirectory).Directory.(*HAMTDirectory); !ok {
+		t.Fatal("UpgradeableDirectory wasn't upgraded to HAMTDirectory")
+	}
+}
+
 func TestDirBuilder(t *testing.T) {
 	ds := mdtest.Mock()
 	dir := NewDirectory(ds)

--- a/io/directory_test.go
+++ b/io/directory_test.go
@@ -100,7 +100,7 @@ func TestDuplicateAddDir(t *testing.T) {
 
 func TestUpgradeableDirectory(t *testing.T) {
 	oldHamtOption := UseHAMTSharding
-	defer func() {UseHAMTSharding = oldHamtOption}()
+	defer func() { UseHAMTSharding = oldHamtOption }()
 
 	ds := mdtest.Mock()
 	UseHAMTSharding = false // Create a BasicDirectory.

--- a/io/directory_test.go
+++ b/io/directory_test.go
@@ -105,7 +105,7 @@ func TestUpgradeableDirectory(t *testing.T) {
 	ds := mdtest.Mock()
 	UseHAMTSharding = false // Create a BasicDirectory.
 	dir := NewDirectory(ds)
-	if _, ok := dir.(UpgradeableDirectory).Directory.(*BasicDirectory); !ok {
+	if _, ok := dir.(*UpgradeableDirectory).Directory.(*BasicDirectory); !ok {
 		t.Fatal("UpgradeableDirectory doesn't contain BasicDirectory")
 	}
 
@@ -117,7 +117,7 @@ func TestUpgradeableDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, ok := dir.(UpgradeableDirectory).Directory.(*HAMTDirectory); !ok {
+	if _, ok := dir.(*UpgradeableDirectory).Directory.(*HAMTDirectory); !ok {
 		t.Fatal("UpgradeableDirectory wasn't upgraded to HAMTDirectory")
 	}
 }


### PR DESCRIPTION
Toward https://github.com/ipfs/go-mfs/issues/86.

To avoid breaking compatibility we change as little as possible here but probably both `HAMTDirectory` and `BasicDirectory` should be made private. (In that case we would export `SwitchToSharding` from `BasicDirectory` to the `UpgradeableDirectory`.)