### PR TITLE
fix(directory): initialize size when computing it

### DIFF
--- a/io/directory.go
+++ b/io/directory.go
@@ -150,6 +150,7 @@ func NewDirectoryFromNode(dserv ipld.DAGService, node ipld.Node) (Directory, err
 }
 
 func (d *BasicDirectory) computeEstimatedSize() {
+	d.estimatedSize = 0
 	d.ForEachLink(nil, func(l *ipld.Link) error {
 		d.addToEstimatedSize(l.Name, l.Cid)
 		return nil


### PR DESCRIPTION
Normally this is called from the constructor with the size cleared but I added the same call to the unlikely case we underflow because of a bug. Maybe that call shouldn't exist in the first place but wasn't sure how to handle that without leaving the computation unbalanced. In any case, this is not an addition like the other functions but a computation from scratch so this is the right fix.