### PR TITLE
Release v0.4.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.1"
+  "version": "v0.4.0"
 }


### PR DESCRIPTION
Note: This should be rebased onto master when ready to make it into master. Also the name of this branch was incorrectly `chore/release-v0.3.2` but we're doing v0.4.0 because there are some changes here notably:

1. The added public function on the HAMT Shards
2. The minimum Go version was bumped to 1.17 from 1.16