### PR TITLE
fix(hamt): catch panic in walkChildren

### DIFF
--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -34,8 +34,11 @@ import (
 	bitfield "github.com/ipfs/go-bitfield"
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+	logging "github.com/ipfs/go-log"
 	dag "github.com/ipfs/go-merkledag"
 )
+
+var log = logging.Logger("unixfs")
 
 const (
 	// HashMurmur3 is the multiformats identifier for Murmur3
@@ -415,8 +418,13 @@ type listCidsAndShards struct {
 func (ds *Shard) walkChildren(processLinkValues func(formattedLink *ipld.Link) error) (*listCidsAndShards, error) {
 	res := &listCidsAndShards{}
 
-	for idx, lnk := range ds.childer.links {
-		if nextShard := ds.childer.children[idx]; nextShard == nil {
+	for i := range ds.childer.children {
+		if nextShard := ds.childer.child(i); nextShard == nil {
+			lnk := ds.childer.link(i)
+			if lnk == nil {
+				log.Warnf("internal HAMT error: both link and shard nil at pos %d, dumping shard: %+v", i, *ds)
+				return nil, fmt.Errorf("internal HAMT error: both link and shard nil, check log")
+			}
 			lnkLinkType, err := ds.childLinkType(lnk)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Catch panic from https://github.com/ipfs/kubo/issues/9063. Both `links` and `children` seem to have a `nil` value at some position of the array (this is inconsistent per our own documentation and should never happen).

I have no idea what's causing this. It could either have been introduced during sharding or just exposed by it. In any case unless this is recurrent I don't see much value in delving deeper, if anything we should be investing in cleaning HAMT internals first.

As a defensive refactoring I'm iterating `children` instead of `links` as the existing `each()` already does for `walkTrie`, but this should be a no-op.