### PR TITLE
Fix: panic when childer is nil

### DIFF
--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -89,7 +89,7 @@ func NewShard(dserv ipld.DAGService, size int) (*Shard, error) {
 	return NewShardValue(dserv, size, "", nil)
 }
 
-// NewShard creates a new, empty HAMT shard with the given key, value and size.
+// NewShardValue creates a new, empty HAMT shard with the given key, value and size.
 func NewShardValue(dserv ipld.DAGService, size int, key string, value *ipld.Link) (*Shard, error) {
 	ds, err := makeShard(dserv, size, key, value)
 	if err != nil {

--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -86,7 +86,12 @@ type Shard struct {
 
 // NewShard creates a new, empty HAMT shard with the given size.
 func NewShard(dserv ipld.DAGService, size int) (*Shard, error) {
-	ds, err := makeShard(dserv, size)
+	return NewShardValue(dserv, size, "", nil)
+}
+
+// NewShard creates a new, empty HAMT shard with the given key, value and size.
+func NewShardValue(dserv ipld.DAGService, size int, key string, value *ipld.Link) (*Shard, error) {
+	ds, err := makeShard(dserv, size, key, value)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +101,7 @@ func NewShard(dserv ipld.DAGService, size int) (*Shard, error) {
 	return ds, nil
 }
 
-func makeShard(ds ipld.DAGService, size int) (*Shard, error) {
+func makeShard(ds ipld.DAGService, size int, key string, val *ipld.Link) (*Shard, error) {
 	lg2s, err := Logtwo(size)
 	if err != nil {
 		return nil, err
@@ -109,6 +114,9 @@ func makeShard(ds ipld.DAGService, size int) (*Shard, error) {
 		childer:      newChilder(ds, size),
 		tableSize:    size,
 		dserv:        ds,
+
+		key: key,
+		val: val,
 	}
 
 	s.childer.sd = s
@@ -138,7 +146,7 @@ func NewHamtFromDag(dserv ipld.DAGService, nd ipld.Node) (*Shard, error) {
 
 	size := int(fsn.Fanout())
 
-	ds, err := makeShard(dserv, size)
+	ds, err := makeShard(dserv, size, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +222,7 @@ func (ds *Shard) Node() (ipld.Node, error) {
 
 func (ds *Shard) makeShardValue(lnk *ipld.Link) (*Shard, error) {
 	lnk2 := *lnk
-	s, err := makeShard(ds.dserv, ds.tableSize)
+	s, err := makeShard(ds.dserv, ds.tableSize, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -795,7 +803,11 @@ func (s *childer) insert(key string, lnk *ipld.Link, idx int) error {
 
 	lnk.Name = s.sd.linkNamePrefix(idx) + key
 	i := s.sliceIndex(idx)
-	sd := &Shard{key: key, val: lnk}
+
+	sd, err := NewShardValue(s.dserv, 256, key, lnk)
+	if err != nil {
+		return err
+	}
 
 	s.children = append(s.children[:i], append([]*Shard{sd}, s.children[i:]...)...)
 	s.links = append(s.links[:i], append([]*ipld.Link{nil}, s.links[i:]...)...)

--- a/hamt/hamt_test.go
+++ b/hamt/hamt_test.go
@@ -435,6 +435,38 @@ func TestDuplicateAddShard(t *testing.T) {
 	}
 }
 
+// fix https://github.com/ipfs/kubo/issues/9063
+func TestSetLink(t *testing.T) {
+	ds := mdtest.Mock()
+	dir, _ := NewShard(ds, 256)
+	_, s, err := makeDir(ds, 300)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lnk, err := s.Link()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	err = dir.SetLink(ctx, "test", lnk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(dir.childer.children) != 1 {
+		t.Fatal("no child")
+	}
+
+	for _, sh := range dir.childer.children {
+		if sh.childer == nil {
+			t.Fatal("no childer on shard")
+		}
+	}
+}
+
 func TestLoadFailsFromNonShard(t *testing.T) {
 	ds := mdtest.Mock()
 	nd := ft.EmptyDirNode()


### PR DESCRIPTION
Context: https://github.com/ipfs/kubo/issues/9063

When stressing `go-mfs` over fuzz testing, we can cause nil pointer exceptions like:
```
testing.go:1349: panic: runtime error: invalid memory address or nil pointer dereference
            goroutine 6908 [running]:
            runtime/debug.Stack()
                /usr/local/go/src/runtime/debug/stack.go:24 +0x90
            testing.tRunner.func1()
                /usr/local/go/src/testing/testing.go:1349 +0x1f2
            panic({0xa6ec60, 0xefe2e0})
                /usr/local/go/src/runtime/panic.go:838 +0x207
            github.com/ipfs/go-unixfs/hamt.(*childer).has(...)
                /home/ajnavarro/go/pkg/mod/github.com/ipfs/go-unixfs@v0.4.0/hamt/hamt.go:886
            github.com/ipfs/go-unixfs/hamt.(*Shard).swapValue(0xc0029067e0, {0xbc1440, 0xc000024088}, 0xc0000e5348, {0xc00014e001, 0xf10}, 0xc002462420)
                /home/ajnavarro/go/pkg/mod/github.com/ipfs/go-unixfs@v0.4.0/hamt/hamt.go:623 +0xa3
            github.com/ipfs/go-unixfs/hamt.(*Shard).swapValue(0xc002906770, {0xbc1440, 0xc000024088}, 0xc0000e5348, {0xc00014e001, 0xf10}, 0xc002462420)
                /home/ajnavarro/go/pkg/mod/github.com/ipfs/go-unixfs@v0.4.0/hamt/hamt.go:689 +0x745
            github.com/ipfs/go-unixfs/hamt.(*Shard).SetLink(0xc002906770, {0xbc1440, 0xc000024088}, {0xc00014e001, 0xf10}, 0xc001fbaf90)
                /home/ajnavarro/go/pkg/mod/github.com/ipfs/go-unixfs@v0.4.0/hamt/hamt.go:248 +0x1f7
            github.com/ipfs/go-unixfs/io.(*BasicDirectory).switchToSharding(0xc00007ca60, {0xbc1440, 0xc000024088})
                /home/ajnavarro/go/pkg/mod/github.com/ipfs/go-unixfs@v0.4.0/io/directory.go:337 +0x2db
            github.com/ipfs/go-unixfs/io.(*DynamicDirectory).AddChild(0xc0002efdd0, {0xbc1440, 0xc000024088}, {0xc0044f9629, 0x2}, {0xbc32b8, 0xc0027f13e0})
                /home/ajnavarro/go/pkg/mod/github.com/ipfs/go-unixfs@v0.4.0/io/directory.go:569 +0x113
            github.com/ipfs/go-mfs.(*Directory).Mkdir(0xc0001a4800, {0xc0044f9629, 0x2})
                /home/ajnavarro/workspace/go-mfs/dir.go:316 +0x516
            github.com/ipfs/go-mfs.Mkdir(0xc0002efdb0, {0xc0044f9629, 0x2}, {0x0?, 0x0?, {0x0?, 0x0?}})
                /home/ajnavarro/workspace/go-mfs/ops.go:175 +0x31f
            github.com/ipfs/go-mfs.FuzzMkdirAndWriteConcurrently.func1(0xc000102680, 0xd0?, 0x57?, {0xc0044f9629, 0x2}, {0x0, 0x0}, {0xc0044f9650, 0x1, 0x8})
                /home/ajnavarro/workspace/go-mfs/mfs_test.go:1540 +0x8d
            reflect.Value.call({0xa75ae0?, 0xc0002efde0?, 0x13?}, {0xaf8ffc, 0x4}, {0xc002548a80, 0x6, 0x8?})
                /usr/local/go/src/reflect/value.go:556 +0x845
            reflect.Value.Call({0xa75ae0?, 0xc0002efde0?, 0x514?}, {0xc002548a80, 0x6, 0x8})
                /usr/local/go/src/reflect/value.go:339 +0xbf
            testing.(*F).Fuzz.func1.1(0x0?)
                /usr/local/go/src/testing/fuzz.go:337 +0x231
            testing.tRunner(0xc000102680, 0xc0000d9290)
                /usr/local/go/src/testing/testing.go:1439 +0x102
            created by testing.(*F).Fuzz.func1
                /usr/local/go/src/testing/fuzz.go:324 +0x5b8
```

This PR patches that problem.

I need some experienced eyes to check that what I did is 100% correct.