### PR TITLE
Update builder.go

### DIFF
--- a/importer/balanced/builder.go
+++ b/importer/balanced/builder.go
@@ -158,7 +158,10 @@ func Layout(db *h.DagBuilderHelper) (ipld.Node, error) {
 
 		// Add the old `root` as a child of the `newRoot`.
 		newRoot := db.NewFSNodeOverDag(ft.TFile)
-		newRoot.AddChild(root, fileSize, db)
+		err = newRoot.AddChild(root, fileSize, db)
+		if err != nil {
+			return nil, err
+		}
 
 		// Fill the `newRoot` (that has the old `root` already as child)
 		// and make it the current `root` for the next iteration (when

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -189,11 +189,10 @@ func (db *DagBuilderHelper) FillNodeLayer(node *FSNodeOverDag) error {
 			return err
 		}
 	}
-	node.Commit()
 	// TODO: Do we need to commit here? The caller who created the
 	// `FSNodeOverDag` should be in charge of that.
-
-	return nil
+	_, err := node.Commit()
+	return err
 }
 
 // NewLeafDataNode builds the `node` with the data obtained from the

--- a/io/directory.go
+++ b/io/directory.go
@@ -164,7 +164,8 @@ func NewDirectoryFromNode(dserv ipld.DAGService, node ipld.Node) (Directory, err
 
 func (d *BasicDirectory) computeEstimatedSize() {
 	d.estimatedSize = 0
-	d.ForEachLink(context.TODO(), func(l *ipld.Link) error {
+	// err is just breaking the iteration and we always return nil
+	_ = d.ForEachLink(context.TODO(), func(l *ipld.Link) error {
 		d.addToEstimatedSize(l.Name, l.Cid)
 		return nil
 	})
@@ -570,7 +571,7 @@ func (d *DynamicDirectory) AddChild(ctx context.Context, name string, nd ipld.No
 	if err != nil {
 		return err
 	}
-	hamtDir.AddChild(ctx, name, nd)
+	err = hamtDir.AddChild(ctx, name, nd)
 	if err != nil {
 		return err
 	}
@@ -600,7 +601,7 @@ func (d *DynamicDirectory) RemoveChild(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	basicDir.RemoveChild(ctx, name)
+	err = basicDir.RemoveChild(ctx, name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this will lose block when newRoot.AddChild returns err. in ipfs-cluster single dag service add(context.TODO(), node) maybe failed when not enough peers to allocate for this block node