### PR TITLE
chore: mark exported types as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ go-unixfs
 
 - [Directory](#directory)
 - [Install](#install)
-- [Contribute](#contribute)
 - [License](#license)
 
 ## Package Directory
@@ -60,12 +59,6 @@ The `test` subpackage provides several utilities to make testing unixfs related 
 ```sh
 go get github.com/ipfs/go-unixfs
 ```
-
-## Contribute
-
-PRs are welcome!
-
-Small note: If editing the Readme, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
 go-unixfs
 ==================
 
+> go-unixfs implements unix-like filesystem utilities on top of an ipld merkledag
+
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![Coverage Status](https://codecov.io/gh/ipfs/go-unixfs/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/go-unixfs/branch/master)
 [![Travis CI](https://travis-ci.org/ipfs/go-unixfs.svg?branch=master)](https://travis-ci.org/ipfs/go-unixfs)
 
-> go-unixfs implements unix-like filesystem utilities on top of an ipld merkledag
+## ❗ This repo is no longer maintained.
 
-## Lead Maintainer
+👉 We highly recommend switching to the maintained version at https://github.com/ipfs/boxo/tree/main/ipld/unixfs.
 
-[Steven Allen](https://github.com/Stebalien)
+🏎️ Good news!  There is [tooling and documentation](https://github.com/ipfs/boxo#migrating-to-boxo) to expedite a switch in your repo. 
+
+⚠️ If you continue using this repo, please note that security fixes will not be provided (unless someone steps in to maintain it).
+
+📚 Learn more, including how to take the maintainership mantle or ask questions, [here](https://github.com/ipfs/boxo/wiki/Copied-or-Migrated-Repos-FAQ).
 
 ## Table of Contents
 

--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -150,6 +150,7 @@ func newUnixfsDir(ctx context.Context, dserv ipld.DAGService, nd *dag.ProtoNode)
 	}, nil
 }
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/file.NewUnixfsFile
 func NewUnixfsFile(ctx context.Context, dserv ipld.DAGService, nd ipld.Node) (files.Node, error) {
 	switch dn := nd.(type) {
 	case *dag.ProtoNode:

--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -41,6 +41,8 @@ import (
 
 const (
 	// HashMurmur3 is the multiformats identifier for Murmur3
+	//
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/hamt.HashMurmur3
 	HashMurmur3 uint64 = 0x22
 )
 
@@ -53,6 +55,8 @@ func (ds *Shard) isValueNode() bool {
 }
 
 // A Shard represents the HAMT. It should be initialized with NewShard().
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/hamt.Shard
 type Shard struct {
 	childer *childer
 
@@ -85,11 +89,15 @@ type Shard struct {
 }
 
 // NewShard creates a new, empty HAMT shard with the given size.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/hamt.NewShard
 func NewShard(dserv ipld.DAGService, size int) (*Shard, error) {
 	return NewShardValue(dserv, size, "", nil)
 }
 
 // NewShardValue creates a new, empty HAMT shard with the given key, value and size.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/hamt.NewShardValue
 func NewShardValue(dserv ipld.DAGService, size int, key string, value *ipld.Link) (*Shard, error) {
 	ds, err := makeShard(dserv, size, key, value)
 	if err != nil {
@@ -129,6 +137,8 @@ func makeShard(ds ipld.DAGService, size int, key string, val *ipld.Link) (*Shard
 }
 
 // NewHamtFromDag creates new a HAMT shard from the given DAG.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/hamt.NewHamtFromDag
 func NewHamtFromDag(dserv ipld.DAGService, nd ipld.Node) (*Shard, error) {
 	pbnd, ok := nd.(*dag.ProtoNode)
 	if !ok {

--- a/hamt/util.go
+++ b/hamt/util.go
@@ -62,6 +62,7 @@ func (hb *hashBits) next(i int) int {
 	}
 }
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/hamt.Logtwo
 func Logtwo(v int) (int, error) {
 	if v <= 0 {
 		return 0, fmt.Errorf("hamt size should be a power of two")

--- a/importer/balanced/builder.go
+++ b/importer/balanced/builder.go
@@ -129,6 +129,8 @@ import (
 //	  +=========+   +=========+   + - - - - +
 //	  | Chunk 1 |   | Chunk 2 |   | Chunk 3 |
 //	  +=========+   +=========+   + - - - - +
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/balanced.Layout
 func Layout(db *h.DagBuilderHelper) (ipld.Node, error) {
 	if db.Done() {
 		// No data, return just an empty node.

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -18,10 +18,13 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.ErrMissingFsRef
 var ErrMissingFsRef = errors.New("missing file path or URL, can't create filestore reference")
 
 // DagBuilderHelper wraps together a bunch of objects needed to
 // efficiently create unixfs dag trees
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.DagBuilderHelper
 type DagBuilderHelper struct {
 	dserv      ipld.DAGService
 	spl        chunker.Splitter
@@ -48,6 +51,8 @@ type DagBuilderHelper struct {
 
 // DagBuilderParams wraps configuration options to create a DagBuilderHelper
 // from a chunker.Splitter.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.DagBuilderParams
 type DagBuilderParams struct {
 	// Maximum number of links per intermediate node
 	Maxlinks int
@@ -283,6 +288,8 @@ func (db *DagBuilderHelper) Maxlinks() int {
 // many possible node state combinations.
 //
 // TODO: Revisit the name.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.FSNodeOverDag
 type FSNodeOverDag struct {
 	dag  *dag.ProtoNode
 	file *ft.FSNode
@@ -308,6 +315,8 @@ func (db *DagBuilderHelper) NewFSNFromDag(nd *dag.ProtoNode) (*FSNodeOverDag, er
 }
 
 // NewFSNFromDag reconstructs a FSNodeOverDag node from a given dag node
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.NewFSNFromDag
 func NewFSNFromDag(nd *dag.ProtoNode) (*FSNodeOverDag, error) {
 	mb, err := ft.FSNodeFromBytes(nd.Data())
 	if err != nil {

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -5,6 +5,8 @@ import (
 )
 
 // BlockSizeLimit specifies the maximum size an imported block can have.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.BlockSizeLimit
 var BlockSizeLimit = 1048576 // 1 MB
 
 // rough estimates on expected sizes
@@ -25,7 +27,11 @@ var roughLinkSize = 34 + 8 + 5   // sha256 multihash + size + no name + protobuf
 //	var DefaultLinksPerBlock = (roughLinkBlockSize / roughLinkSize)
 //	                         = ( 8192 / 47 )
 //	                         = (approximately) 174
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.DefaultLinksPerBlock
 var DefaultLinksPerBlock = roughLinkBlockSize / roughLinkSize
 
 // ErrSizeLimitExceeded signals that a block is larger than BlockSizeLimit.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/helpers.ErrSizeLimitExceeded
 var ErrSizeLimitExceeded = fmt.Errorf("object size limit exceeded")

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -13,6 +13,8 @@ import (
 
 // BuildDagFromReader creates a DAG given a DAGService and a Splitter
 // implementation (Splitters are io.Readers), using a Balanced layout.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer.BuildDagFromReader
 func BuildDagFromReader(ds ipld.DAGService, spl chunker.Splitter) (ipld.Node, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
@@ -27,6 +29,8 @@ func BuildDagFromReader(ds ipld.DAGService, spl chunker.Splitter) (ipld.Node, er
 
 // BuildTrickleDagFromReader creates a DAG given a DAGService and a Splitter
 // implementation (Splitters are io.Readers), using a Trickle Layout.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer.BuildTrickleDagFromReader
 func BuildTrickleDagFromReader(ds ipld.DAGService, spl chunker.Splitter) (ipld.Node, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,

--- a/importer/trickle/trickledag.go
+++ b/importer/trickle/trickledag.go
@@ -36,6 +36,8 @@ const depthRepeat = 4
 // Layout builds a new DAG with the trickle format using the provided
 // DagBuilderHelper. See the module's description for a more detailed
 // explanation.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/trickle.Layout
 func Layout(db *h.DagBuilderHelper) (ipld.Node, error) {
 	newRoot := db.NewFSNodeOverDag(ft.TFile)
 	root, _, err := fillTrickleRec(db, newRoot, -1)
@@ -87,6 +89,8 @@ func fillTrickleRec(db *h.DagBuilderHelper, node *h.FSNodeOverDag, maxDepth int)
 }
 
 // Append appends the data in `db` to the dag, using the Trickledag format
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/trickle.Append
 func Append(ctx context.Context, basen ipld.Node, db *h.DagBuilderHelper) (out ipld.Node, errOut error) {
 	base, ok := basen.(*dag.ProtoNode)
 	if !ok {
@@ -276,6 +280,8 @@ func trickleDepthInfo(node *h.FSNodeOverDag, maxlinks int) (depth int, repeatNum
 }
 
 // VerifyParams is used by VerifyTrickleDagStructure
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/trickle.VerifyParams
 type VerifyParams struct {
 	Getter      ipld.NodeGetter
 	Direct      int
@@ -286,6 +292,8 @@ type VerifyParams struct {
 
 // VerifyTrickleDagStructure checks that the given dag matches exactly the trickle dag datastructure
 // layout
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/importer/trickle.VerifyTrickleDagStructure
 func VerifyTrickleDagStructure(nd ipld.Node, p VerifyParams) error {
 	return verifyTDagRec(nd, -1, p)
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,3 +1,4 @@
 package internal
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/internal.HAMTHashFunction
 var HAMTHashFunction func(val []byte) []byte

--- a/io/dagreader.go
+++ b/io/dagreader.go
@@ -13,9 +13,13 @@ import (
 
 // Common errors
 var (
-	ErrIsDir            = errors.New("this dag node is a directory")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.ErrIsDir
+	ErrIsDir = errors.New("this dag node is a directory")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.ErrCantReadSymlinks
 	ErrCantReadSymlinks = errors.New("cannot currently read symlinks")
-	ErrUnkownNodeType   = errors.New("unknown node type")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.ErrUnkownNodeType
+	ErrUnkownNodeType = errors.New("unknown node type")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.ErrSeekNotSupported
 	ErrSeekNotSupported = errors.New("file does not support seeking")
 )
 
@@ -26,6 +30,8 @@ var (
 // A DagReader provides read-only read and seek acess to a unixfs file.
 // Different implementations of readers are used for the different
 // types of unixfs/protobuf-encoded nodes.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.DagReader
 type DagReader interface {
 	ReadSeekCloser
 	Size() uint64
@@ -33,6 +39,8 @@ type DagReader interface {
 }
 
 // A ReadSeekCloser implements interfaces to read, copy, seek and close.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.ReadSeekCloser
 type ReadSeekCloser interface {
 	io.Reader
 	io.Seeker
@@ -42,6 +50,8 @@ type ReadSeekCloser interface {
 
 // NewDagReader creates a new reader object that reads the data represented by
 // the given node, using the passed in DAGService for data retrieval.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.NewDagReader
 func NewDagReader(ctx context.Context, n ipld.Node, serv ipld.NodeGetter) (DagReader, error) {
 	var size uint64
 

--- a/io/directory.go
+++ b/io/directory.go
@@ -24,10 +24,14 @@ var log = logging.Logger("unixfs")
 // The size is not the *exact* block size of the encoded BasicDirectory but just
 // the estimated size based byte length of links name and CID (BasicDirectory's
 // ProtoNode doesn't use the Data field so this estimate is pretty accurate).
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.HAMTShardingSize
 var HAMTShardingSize = int(256 * units.KiB)
 
 // DefaultShardWidth is the default value used for hamt sharding width.
 // Needs to be a power of two (shard entry size) and multiple of 8 (bitfield size).
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.DefaultShardWidth
 var DefaultShardWidth = 256
 
 // Directory defines a UnixFS directory. It is used for creating, reading and
@@ -37,6 +41,8 @@ var DefaultShardWidth = 256
 // It just allows to perform explicit edits on a single directory, working with
 // directory trees is out of its scope, they are managed by the MFS layer
 // (which is the main consumer of this interface).
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.Directory
 type Directory interface {
 
 	// SetCidBuilder sets the CID Builder of the root node.
@@ -88,6 +94,8 @@ func init() {
 
 // BasicDirectory is the basic implementation of `Directory`. All the entries
 // are stored in a single node.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.BasicDirectory
 type BasicDirectory struct {
 	node  *mdag.ProtoNode
 	dserv ipld.DAGService
@@ -102,6 +110,8 @@ type BasicDirectory struct {
 
 // HAMTDirectory is the HAMT implementation of `Directory`.
 // (See package `hamt` for more information.)
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.HAMTDirectory
 type HAMTDirectory struct {
 	shard *hamt.Shard
 	dserv ipld.DAGService
@@ -128,15 +138,21 @@ func newBasicDirectoryFromNode(dserv ipld.DAGService, node *mdag.ProtoNode) *Bas
 
 // NewDirectory returns a Directory implemented by DynamicDirectory
 // containing a BasicDirectory that can be converted to a HAMTDirectory.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.NewDirectory
 func NewDirectory(dserv ipld.DAGService) Directory {
 	return &DynamicDirectory{newEmptyBasicDirectory(dserv)}
 }
 
 // ErrNotADir implies that the given node was not a unixfs directory
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.ErrNotADir
 var ErrNotADir = fmt.Errorf("merkledag node was not a directory or shard")
 
 // NewDirectoryFromNode loads a unixfs directory from the given IPLD node and
 // DAGService.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.NewDirectoryFromNode
 func NewDirectoryFromNode(dserv ipld.DAGService, node ipld.Node) (Directory, error) {
 	protoBufNode, ok := node.(*mdag.ProtoNode)
 	if !ok {
@@ -523,6 +539,8 @@ func (d *HAMTDirectory) sizeBelowThreshold(ctx context.Context, sizeChange int) 
 // DynamicDirectory wraps a Directory interface and provides extra logic
 // to switch from BasicDirectory to HAMTDirectory and backwards based on
 // size.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.DynamicDirectory
 type DynamicDirectory struct {
 	Directory
 }

--- a/io/resolve.go
+++ b/io/resolve.go
@@ -12,6 +12,8 @@ import (
 
 // ResolveUnixfsOnce resolves a single hop of a path through a graph in a
 // unixfs context. This includes handling traversing sharded directories.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/io.ResolveUnixfsOnce
 func ResolveUnixfsOnce(ctx context.Context, ds ipld.NodeGetter, nd ipld.Node, names []string) (*ipld.Link, []string, error) {
 	pn, ok := nd.(*dag.ProtoNode)
 	if ok {

--- a/mod/dagmodifier.go
+++ b/mod/dagmodifier.go
@@ -21,9 +21,12 @@ import (
 
 // Common errors
 var (
-	ErrSeekFail           = errors.New("failed to seek properly")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/mod.ErrSeekFail
+	ErrSeekFail = errors.New("failed to seek properly")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/mod.ErrUnrecognizedWhence
 	ErrUnrecognizedWhence = errors.New("unrecognized whence")
-	ErrNotUnixfs          = errors.New("dagmodifier only supports unixfs nodes (proto or raw)")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/mod.ErrNotUnixfs
+	ErrNotUnixfs = errors.New("dagmodifier only supports unixfs nodes (proto or raw)")
 )
 
 // 2MB
@@ -32,6 +35,8 @@ var writebufferSize = 1 << 21
 // DagModifier is the only struct licensed and able to correctly
 // perform surgery on a DAG 'file'
 // Dear god, please rename this to something more pleasant
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/mod.DagModifier
 type DagModifier struct {
 	dagserv ipld.DAGService
 	curNode ipld.Node
@@ -54,6 +59,8 @@ type DagModifier struct {
 // created nodes will be inhered from the passed in node.  If the Cid
 // version if not 0 raw leaves will also be enabled.  The Prefix and
 // RawLeaves options can be overridden by changing them after the call.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/mod.NewDagModifier
 func NewDagModifier(ctx context.Context, from ipld.Node, serv ipld.DAGService, spl chunker.SplitterGen) (*DagModifier, error) {
 	switch from.(type) {
 	case *mdag.ProtoNode, *mdag.RawNode:

--- a/pb/unixfs.pb.go
+++ b/pb/unixfs.pb.go
@@ -21,17 +21,25 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_DataType
 type Data_DataType int32
 
 const (
-	Data_Raw       Data_DataType = 0
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_Raw
+	Data_Raw Data_DataType = 0
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_Directory
 	Data_Directory Data_DataType = 1
-	Data_File      Data_DataType = 2
-	Data_Metadata  Data_DataType = 3
-	Data_Symlink   Data_DataType = 4
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_File
+	Data_File Data_DataType = 2
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_Metadata
+	Data_Metadata Data_DataType = 3
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_Symlink
+	Data_Symlink Data_DataType = 4
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_HAMTShard
 	Data_HAMTShard Data_DataType = 5
 )
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_DataType_name
 var Data_DataType_name = map[int32]string{
 	0: "Raw",
 	1: "Directory",
@@ -41,6 +49,7 @@ var Data_DataType_name = map[int32]string{
 	5: "HAMTShard",
 }
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data_DataType_value
 var Data_DataType_value = map[string]int32{
 	"Raw":       0,
 	"Directory": 1,
@@ -73,6 +82,7 @@ func (Data_DataType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e2fd76cc44dfc7c3, []int{0, 0}
 }
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Data
 type Data struct {
 	Type                 *Data_DataType `protobuf:"varint,1,req,name=Type,enum=unixfs.pb.Data_DataType" json:"Type,omitempty"`
 	Data                 []byte         `protobuf:"bytes,2,opt,name=Data" json:"Data,omitempty"`
@@ -151,6 +161,7 @@ func (m *Data) GetFanout() uint64 {
 	return 0
 }
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/pb.Metadata
 type Metadata struct {
 	MimeType             *string  `protobuf:"bytes,1,opt,name=MimeType" json:"MimeType,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/private/linksize/linksize.go
+++ b/private/linksize/linksize.go
@@ -2,4 +2,5 @@ package linksize
 
 import "github.com/ipfs/go-cid"
 
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/private/linksize.LinkSizeFunction
 var LinkSizeFunction func(linkName string, linkCid cid.Cid) int

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["inherit", "-SA1019"]

--- a/test/utils.go
+++ b/test/utils.go
@@ -21,6 +21,8 @@ import (
 )
 
 // SizeSplitterGen creates a generator.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.SizeSplitterGen
 func SizeSplitterGen(size int64) chunker.SplitterGen {
 	return func(r io.Reader) chunker.Splitter {
 		return chunker.NewSizeSplitter(r, size)
@@ -28,11 +30,15 @@ func SizeSplitterGen(size int64) chunker.SplitterGen {
 }
 
 // GetDAGServ returns a mock DAGService.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.GetDAGServ
 func GetDAGServ() ipld.DAGService {
 	return mdagmock.Mock()
 }
 
 // NodeOpts is used by GetNode, GetEmptyNode and GetRandomNode
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.NodeOpts
 type NodeOpts struct {
 	Prefix cid.Prefix
 	// ForceRawLeaves if true will force the use of raw leaves
@@ -43,10 +49,14 @@ type NodeOpts struct {
 
 // Some shorthands for NodeOpts.
 var (
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.UseProtoBufLeaves
 	UseProtoBufLeaves = NodeOpts{Prefix: mdag.V0CidPrefix()}
-	UseRawLeaves      = NodeOpts{Prefix: mdag.V0CidPrefix(), ForceRawLeaves: true, RawLeavesUsed: true}
-	UseCidV1          = NodeOpts{Prefix: mdag.V1CidPrefix(), RawLeavesUsed: true}
-	UseBlake2b256     NodeOpts
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.UseRawLeaves
+	UseRawLeaves = NodeOpts{Prefix: mdag.V0CidPrefix(), ForceRawLeaves: true, RawLeavesUsed: true}
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.UseCidV1
+	UseCidV1 = NodeOpts{Prefix: mdag.V1CidPrefix(), RawLeavesUsed: true}
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.UseBlake2b256
+	UseBlake2b256 NodeOpts
 )
 
 func init() {
@@ -56,6 +66,8 @@ func init() {
 }
 
 // GetNode returns a unixfs file node with the specified data.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.GetNode
 func GetNode(t testing.TB, dserv ipld.DAGService, data []byte, opts NodeOpts) ipld.Node {
 	in := bytes.NewReader(data)
 
@@ -79,11 +91,15 @@ func GetNode(t testing.TB, dserv ipld.DAGService, data []byte, opts NodeOpts) ip
 }
 
 // GetEmptyNode returns an empty unixfs file node.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.GetEmptyNode
 func GetEmptyNode(t testing.TB, dserv ipld.DAGService, opts NodeOpts) ipld.Node {
 	return GetNode(t, dserv, []byte{}, opts)
 }
 
 // GetRandomNode returns a random unixfs file node.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.GetRandomNode
 func GetRandomNode(t testing.TB, dserv ipld.DAGService, size int64, opts NodeOpts) ([]byte, ipld.Node) {
 	in := io.LimitReader(u.NewTimeSeededRand(), size)
 	buf, err := io.ReadAll(in)
@@ -96,6 +112,8 @@ func GetRandomNode(t testing.TB, dserv ipld.DAGService, size int64, opts NodeOpt
 }
 
 // ArrComp checks if two byte slices are the same.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.ArrComp
 func ArrComp(a, b []byte) error {
 	if len(a) != len(b) {
 		return fmt.Errorf("arrays differ in length. %d != %d", len(a), len(b))
@@ -109,6 +127,8 @@ func ArrComp(a, b []byte) error {
 }
 
 // PrintDag pretty-prints the given dag to stdout.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs/test.PrintDag
 func PrintDag(nd *mdag.ProtoNode, ds ipld.DAGService, indent int) {
 	fsn, err := ft.FSNodeFromBytes(nd.Data())
 	if err != nil {

--- a/unixfs.go
+++ b/unixfs.go
@@ -16,6 +16,8 @@ import (
 
 // A LinkResult for any parallel enumeration of links
 // TODO: Should this live in go-ipld-format?
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.LinkResult
 type LinkResult struct {
 	Link *ipld.Link
 	Err  error
@@ -23,22 +25,32 @@ type LinkResult struct {
 
 // Shorthands for protobuffer types
 const (
-	TRaw       = pb.Data_Raw
-	TFile      = pb.Data_File
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.TRaw
+	TRaw = pb.Data_Raw
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.TFile
+	TFile = pb.Data_File
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.TDirectory
 	TDirectory = pb.Data_Directory
-	TMetadata  = pb.Data_Metadata
-	TSymlink   = pb.Data_Symlink
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.TMetadata
+	TMetadata = pb.Data_Metadata
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.TSymlink
+	TSymlink = pb.Data_Symlink
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.THAMTShard
 	THAMTShard = pb.Data_HAMTShard
 )
 
 // Common errors
 var (
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.ErrMalformedFileFormat
 	ErrMalformedFileFormat = errors.New("malformed data in file format")
-	ErrUnrecognizedType    = errors.New("unrecognized node type")
+	// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.ErrUnrecognizedType
+	ErrUnrecognizedType = errors.New("unrecognized node type")
 )
 
 // FromBytes unmarshals a byte slice as protobuf Data.
 // Deprecated: Use `FSNodeFromBytes` instead to avoid direct manipulation of `pb.Data`.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.FromBytes
 func FromBytes(data []byte) (*pb.Data, error) {
 	pbdata := new(pb.Data)
 	err := proto.Unmarshal(data, pbdata)
@@ -50,6 +62,8 @@ func FromBytes(data []byte) (*pb.Data, error) {
 
 // FilePBData creates a protobuf File with the given
 // byte slice and returns the marshaled protobuf bytes representing it.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.FilePBData
 func FilePBData(data []byte, totalsize uint64) []byte {
 	pbfile := new(pb.Data)
 	typ := pb.Data_File
@@ -70,6 +84,8 @@ func FilePBData(data []byte, totalsize uint64) []byte {
 }
 
 // FolderPBData returns Bytes that represent a Directory.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.FolderPBData
 func FolderPBData() []byte {
 	pbfile := new(pb.Data)
 	typ := pb.Data_Directory
@@ -84,6 +100,8 @@ func FolderPBData() []byte {
 }
 
 // WrapData marshals raw bytes into a `Data_Raw` type protobuf message.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.WrapData
 func WrapData(b []byte) []byte {
 	pbdata := new(pb.Data)
 	typ := pb.Data_Raw
@@ -101,6 +119,8 @@ func WrapData(b []byte) []byte {
 }
 
 // SymlinkData returns a `Data_Symlink` protobuf message for the path you specify.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.SymlinkData
 func SymlinkData(path string) ([]byte, error) {
 	pbdata := new(pb.Data)
 	typ := pb.Data_Symlink
@@ -116,6 +136,8 @@ func SymlinkData(path string) ([]byte, error) {
 }
 
 // HAMTShardData return a `Data_HAMTShard` protobuf message
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.HAMTShardData
 func HAMTShardData(data []byte, fanout uint64, hashType uint64) ([]byte, error) {
 	pbdata := new(pb.Data)
 	typ := pb.Data_HAMTShard
@@ -133,6 +155,8 @@ func HAMTShardData(data []byte, fanout uint64, hashType uint64) ([]byte, error) 
 }
 
 // UnwrapData unmarshals a protobuf messages and returns the contents.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.UnwrapData
 func UnwrapData(data []byte) ([]byte, error) {
 	pbdata := new(pb.Data)
 	err := proto.Unmarshal(data, pbdata)
@@ -146,6 +170,8 @@ func UnwrapData(data []byte) ([]byte, error) {
 // For raw data it simply provides the length of it. For Data_Files, it
 // will return the associated filesize. Note that Data_Directories will
 // return an error.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.DataSize
 func DataSize(data []byte) (uint64, error) {
 	pbdata := new(pb.Data)
 	err := proto.Unmarshal(data, pbdata)
@@ -173,6 +199,8 @@ func size(pbdata *pb.Data) (uint64, error) {
 // The `NewFSNode` constructor should be used instead of just calling `new(FSNode)`
 // to guarantee that the required (`Type` and `Filesize`) fields in the `format`
 // structure are initialized before marshaling (in `GetBytes()`).
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.FSNode
 type FSNode struct {
 
 	// UnixFS format defined as a protocol buffers message.
@@ -180,6 +208,8 @@ type FSNode struct {
 }
 
 // FSNodeFromBytes unmarshal a protobuf message onto an FSNode.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.FSNodeFromBytes
 func FSNodeFromBytes(b []byte) (*FSNode, error) {
 	n := new(FSNode)
 	err := proto.Unmarshal(b, &n.format)
@@ -202,6 +232,8 @@ func FSNodeFromBytes(b []byte) (*FSNode, error) {
 // (If it wasn't initialized there could be cases where `Filesize` could
 // have been left at nil, when the `FSNode` was created but no data or
 // child nodes were set to adjust it, as is the case in `NewLeaf()`.)
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.NewFSNode
 func NewFSNode(dataType pb.Data_DataType) *FSNode {
 	n := new(FSNode)
 	n.format.Type = &dataType
@@ -305,6 +337,8 @@ func (n *FSNode) IsDir() bool {
 }
 
 // Metadata is used to store additional FSNode information.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.Metadata
 type Metadata struct {
 	MimeType string
 	Size     uint64
@@ -312,6 +346,8 @@ type Metadata struct {
 
 // MetadataFromBytes Unmarshals a protobuf Data message into Metadata.
 // The provided slice should have been encoded with BytesForMetadata().
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.MetadataFromBytes
 func MetadataFromBytes(b []byte) (*Metadata, error) {
 	pbd := new(pb.Data)
 	err := proto.Unmarshal(b, pbd)
@@ -342,6 +378,8 @@ func (m *Metadata) Bytes() ([]byte, error) {
 // BytesForMetadata wraps the given Metadata as a profobuf message of Data type,
 // setting the DataType to Metadata. The wrapped bytes are itself the
 // result of calling m.Bytes().
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.BytesForMetadata
 func BytesForMetadata(m *Metadata) ([]byte, error) {
 	pbd := new(pb.Data)
 	pbd.Filesize = proto.Uint64(m.Size)
@@ -357,11 +395,15 @@ func BytesForMetadata(m *Metadata) ([]byte, error) {
 }
 
 // EmptyDirNode creates an empty folder Protonode.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.EmptyDirNode
 func EmptyDirNode() *dag.ProtoNode {
 	return dag.NodeWithData(FolderPBData())
 }
 
 // EmptyFileNode creates an empty file Protonode.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.EmptyFileNode
 func EmptyFileNode() *dag.ProtoNode {
 	return dag.NodeWithData(FilePBData(nil, 0))
 }
@@ -369,6 +411,8 @@ func EmptyFileNode() *dag.ProtoNode {
 // ReadUnixFSNodeData extracts the UnixFS data from an IPLD node.
 // Raw nodes are (also) processed because they are used as leaf
 // nodes containing (only) UnixFS data.
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.ReadUnixFSNodeData
 func ReadUnixFSNodeData(node ipld.Node) (data []byte, err error) {
 	switch node := node.(type) {
 
@@ -403,6 +447,8 @@ func ReadUnixFSNodeData(node ipld.Node) (data []byte, err error) {
 
 // Extract the `unixfs.FSNode` from the `ipld.Node` (assuming this
 // was implemented by a `mdag.ProtoNode`).
+//
+// Deprecated: use github.com/ipfs/boxo/ipld/unixfs.ExtractFSNode
 func ExtractFSNode(node ipld.Node) (*FSNode, error) {
 	protoNode, ok := node.(*dag.ProtoNode)
 	if !ok {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.5"
+  "version": "v0.4.6"
 }


### PR DESCRIPTION
This is the result of running the deprecator on this repo, see https://github.com/ipfs/boxo/pull/297